### PR TITLE
Moved error reporting logic to ExtendedClient

### DIFF
--- a/__mocks__/discordMocks.js
+++ b/__mocks__/discordMocks.js
@@ -8,7 +8,8 @@ export const clientMock = {
     {
       send: jest.fn()
     }
-  ]
+  ],
+  handleError: jest.fn()
 };
 
 export const guildMock = {

--- a/__mocks__/discordMocks.js
+++ b/__mocks__/discordMocks.js
@@ -38,10 +38,12 @@ export const messageMock = {
   guild: guildMock,
   say: jest.fn(),
   channel: {
+    id: '345',
     messages: {
       fetch: jest.fn()
     }
-  }
+  },
+  react: jest.fn(() => Promise.resolve())
 };
 
 export const channelMock = {

--- a/__mocks__/discordMocks.js
+++ b/__mocks__/discordMocks.js
@@ -15,11 +15,13 @@ export const guildMock = {
   channels: {
     cache: {
       find: jest.fn()
-    }
+    },
+    create: jest.fn(() => Promise.resolve)
   },
   roles: {
     cache: {
-      find: jest.fn()
+      find: jest.fn(),
+      map: jest.fn()
     }
   },
   id: '123',
@@ -53,4 +55,9 @@ export const roleMock = {
   name: 'name',
   id: '123',
   mentionable: true
+};
+
+export const userMock = {
+  id: '123',
+  username: 'user'
 };

--- a/src/app.js
+++ b/src/app.js
@@ -5,7 +5,7 @@ import logger from '@greencoast/logger';
 import path from 'path';
 import { discordToken, prefix, ownerID, inviteURL } from './common/settings';
 import { SUPPORT_EMOJI, guildSettingKeys, discordErrors } from './common/constants';
-import { isThisTheDiscordError} from './common/utils/helpers';
+import { isThisTheDiscordError } from './common/utils/helpers';
 import { dbFilePath, dbFileExists, createDatabaseFile, imageDirectoryExists, createImageDirectory } from './common/utils/data';
 import ExtendedClient from './classes/extensions/ExtendedClient';
 
@@ -93,7 +93,7 @@ client.on('messageReactionAdd', async(reaction, user) => {
 
       channel.send(`Please hang tight ${user.username}, <@&${staffRoleID}> will get to you shortly.`);
       logger.info(`Support channel ${channel.name} has been created in ${guild.name}.`);
-      
+
       client.updatePresence();
     })
     .catch((error) => {

--- a/src/app.js
+++ b/src/app.js
@@ -31,7 +31,7 @@ if (process.argv[2] === '--debug') {
 }
 
 client.on('error', (error) => {
-  logger.error(error);
+  client.handleError(error);
 });
 
 client.on('guildCreate', (guild) => {
@@ -71,7 +71,7 @@ client.on('messageReactionAdd', async(reaction, user) => {
         logger.warn(`I don't have enough permissions in ${guild.name} to remove reactions!`);
         return;
       }
-      logger.error(error);
+      client.handleError(error, guild);
     });
 
   if (reaction.emoji.name !== SUPPORT_EMOJI) {
@@ -113,7 +113,7 @@ client.on('messageReactionAdd', async(reaction, user) => {
       }
 
       logger.error(`There was an error creating the support channel for ${user.username} from ${guild.name}.`);
-      logger.error(error);
+      client.handleError(error, guild, `There was an error creating the support channel for ${user.username} from ${guild.name}.`);
     });
 });
 
@@ -154,11 +154,13 @@ client.on('ready', () => {
           });
         })
         .catch((error) => {
-          logger.error(error);
+          logger.fatal('Could not set database as provider!');
+          logger.fatal(error);
         });
     })
     .catch((error) => {
-      logger.error(error);
+      logger.fatal('Could not load the database!');
+      logger.fatal(error);
     });
 });
 

--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,8 @@ import sqlite3 from 'sqlite3';
 import logger from '@greencoast/logger';
 import path from 'path';
 import { discordToken, prefix, ownerID, inviteURL } from './common/settings';
+import { SUPPORT_EMOJI, guildSettingKeys, discordErrors } from './common/constants';
+import { isThisTheDiscordError} from './common/utils/helpers';
 import { dbFilePath, dbFileExists, createDatabaseFile, imageDirectoryExists, createImageDirectory } from './common/utils/data';
 import ExtendedClient from './classes/extensions/ExtendedClient';
 
@@ -51,6 +53,70 @@ client.on('invalidated', () => {
   process.exit(1);
 });
 
+client.on('messageReactionAdd', async(reaction, user) => {
+  const { guild } = reaction.message;
+  const ticket = client.provider.get(guild.id, guildSettingKeys.ticketMessage, null);
+
+  if (user.bot || ticket?.message !== reaction.message.id) {
+    return;
+  }
+
+  if (reaction.partial) {
+    await reaction.fetch();
+  }
+
+  reaction.users.remove(user)
+    .catch((error) => {
+      if (isThisTheDiscordError(error, discordErrors.missingPermissions)) {
+        logger.warn(`I don't have enough permissions in ${guild.name} to remove reactions!`);
+        return;
+      }
+      logger.error(error);
+    });
+
+  if (reaction.emoji.name !== SUPPORT_EMOJI) {
+    return;
+  }
+
+  const currentTickets = client.provider.get(guild.id, guildSettingKeys.currentTickets, []);
+  const userHasTicket = currentTickets.some((ticket) => ticket.user === user.id);
+
+  if (userHasTicket) {
+    user.send('You already have a pending ticket. Please wait for staff to assist you.');
+    return;
+  }
+
+  client.createSupportChannel(guild, user)
+    .then(({ channel, staffRoleID }) => {
+      const newTickets = [...currentTickets, { channel: channel.id, user: user.id }];
+      client.provider.set(guild.id, guildSettingKeys.currentTickets, newTickets);
+
+      channel.send(`Please hang tight ${user.username}, <@&${staffRoleID}> will get to you shortly.`);
+      logger.info(`Support channel ${channel.name} has been created in ${guild.name}.`);
+      
+      client.updatePresence();
+    })
+    .catch((error) => {
+      if (error.message === 'Role does not exist in database.') {
+        logger.warn(`Could not create support channel for ${user.username} in ${guild.name}, a staff role has not been assigned yet.`);
+        return;
+      }
+
+      if (error.message === 'Channel category does not exist in database.') {
+        logger.warn(`Could not create support channel for ${user.username} in ${guild.name}, a channel category has not been assigned yet.`);
+        return;
+      }
+
+      if (isThisTheDiscordError(error, discordErrors.missingPermissions)) {
+        logger.warn(`I don't have enough permissions in ${guild.name} to create channels!`);
+        return;
+      }
+
+      logger.error(`There was an error creating the support channel for ${user.username} from ${guild.name}.`);
+      logger.error(error);
+    });
+});
+
 client.on('rateLimit', (info) => {
   logger.warn(info);
 });
@@ -79,6 +145,13 @@ client.on('ready', () => {
         .then(() => {
           logger.info('Database loaded.');
           client.updatePresence();
+
+          client.guilds.cache.each((guild) => {
+            const ticket = client.provider.get(guild.id, guildSettingKeys.ticketMessage, null);
+            if (ticket) {
+              guild.channels.cache.find((channel) => channel.id === ticket.channel).messages.fetch(ticket.message);
+            }
+          });
         })
         .catch((error) => {
           logger.error(error);

--- a/src/classes/extensions/CustomCommand.js
+++ b/src/classes/extensions/CustomCommand.js
@@ -2,18 +2,10 @@
 /* eslint-disable max-params */
 import { Command } from 'discord.js-commando';
 import logger from '@greencoast/logger';
-import { guildSettingKeys } from '../../common/constants';
 
 class CustomCommand extends Command {
   onError(err, message, args, fromPattern, result) {
-    logger.error(err);
-
-    if (this.client.provider.get(message.guild, guildSettingKeys.report, false)) {
-      this.client.owners.forEach((owner) => {
-        owner.send(`An error occurred when running the command **${this.name}** in **${message.guild.name}**. Triggering message: **${message.content}** \`\`\`${err.stack}\`\`\``);
-      });
-    }
-
+    this.client.handleError(err, message.guild, `An error occurred when running the command **${this.name}** in **${message.guild.name}**. Triggering message: **${message.content}**`);
     return message.reply('Something wrong happened when executing this command.');
   }
 

--- a/src/classes/extensions/ExtendedClient.js
+++ b/src/classes/extensions/ExtendedClient.js
@@ -74,7 +74,7 @@ class ExtendedClient extends CommandoClient {
         reason: `Support channel for **${user.username}**`
       })
         .then((channel) => {
-          resolve(channel);
+          resolve({ channel, staffRoleID });
         })
         .catch((error) => {
           reject(error);

--- a/src/classes/extensions/ExtendedClient.js
+++ b/src/classes/extensions/ExtendedClient.js
@@ -81,6 +81,21 @@ class ExtendedClient extends CommandoClient {
         });
     });
   }
+
+  handleError(error, guild = null, info = null) {
+    logger.error(error);
+
+    if (!guild) {
+      return;
+    }
+
+    if (this.provider.get(guild, guildSettingKeys.report, false)) {
+      const messageToOwner = info ? `${info} \`\`\`${error.stack}\`\`\`` : `An error has ocurred: \`\`\`${error.stack}\`\`\``;
+      this.owners.forEach((owner) => {
+        owner.send(messageToOwner);
+      });
+    }
+  }
 }
 
 export default ExtendedClient;

--- a/src/classes/extensions/ExtendedClient.js
+++ b/src/classes/extensions/ExtendedClient.js
@@ -1,0 +1,31 @@
+import { CommandoClient } from 'discord.js-commando';
+import logger from '@greencoast/logger';
+import { presenceStatus, activityType, guildSettingKeys } from '../../common/constants';
+
+class ExtendedClient extends CommandoClient {
+  updatePresence() {
+    const numberOfGuilds = this.guilds.cache.array().length;
+    const numberOfTickets = this.guilds.cache.reduce((total, guild) => {
+      return total + this.provider.get(guild, guildSettingKeys.currentTickets, []).length;
+    }, 0);
+
+    const presenceMessage = numberOfGuilds === 1 ?
+      `${numberOfTickets} tickets open!` :
+      `${numberOfTickets} tickets open across ${numberOfGuilds} servers!`;
+
+    return this.user.setPresence({
+      status: presenceStatus.online,
+      afk: false,
+      activity: {
+        name: presenceMessage,
+        type: activityType.watching
+      }
+    }).then(() => {
+      logger.info(`Presence updated to: ${presenceMessage}`);
+    }).catch((error) => {
+      logger.error(error);
+    });
+  }
+}
+
+export default ExtendedClient;

--- a/src/classes/extensions/ExtendedClient.js
+++ b/src/classes/extensions/ExtendedClient.js
@@ -1,6 +1,7 @@
 import { CommandoClient } from 'discord.js-commando';
+import { Permissions } from 'discord.js';
 import logger from '@greencoast/logger';
-import { presenceStatus, activityType, guildSettingKeys } from '../../common/constants';
+import { presenceStatus, activityType, guildSettingKeys, SUPPORT_CHANNEL_PERMISSIONS } from '../../common/constants';
 
 class ExtendedClient extends CommandoClient {
   updatePresence() {
@@ -24,6 +25,60 @@ class ExtendedClient extends CommandoClient {
       logger.info(`Presence updated to: ${presenceMessage}`);
     }).catch((error) => {
       logger.error(error);
+    });
+  }
+
+  createSupportChannel(guild, user) {
+    return new Promise((resolve, reject) => {
+      const staffRoleID = this.provider.get(guild, guildSettingKeys.staffRole, null);
+      if (!staffRoleID) {
+        reject(new Error('Role does not exist in database.'));
+        return;
+      }
+
+      const channelCategoryID = this.provider.get(guild, guildSettingKeys.channelCategory, null);
+      if (!channelCategoryID) {
+        reject(new Error('Channel category does not exist in database.'));
+        return;
+      }
+
+      const permissions = guild.roles.cache.map((role) => {
+        const overwrite = {
+          id: role.id,
+          type: 'role'
+        };
+
+        if (role.id === staffRoleID) {
+          overwrite.allow = new Permissions().add(...SUPPORT_CHANNEL_PERMISSIONS);
+        } else {
+          overwrite.deny = Permissions.ALL;
+        }
+
+        return overwrite;
+      });
+      permissions.push({
+        id: user.id,
+        type: 'member',
+        allow: new Permissions().add(...SUPPORT_CHANNEL_PERMISSIONS)
+      }, {
+        id: this.user.id,
+        type: 'member',
+        allow: new Permissions().add(...SUPPORT_CHANNEL_PERMISSIONS)
+      });
+
+      guild.channels.create(`ticket-${user.username}`, {
+        type: 'text',
+        topic: `Support channel for **${user.username}**`,
+        parent: channelCategoryID,
+        permissionOverwrites: permissions,
+        reason: `Support channel for **${user.username}**`
+      })
+        .then((channel) => {
+          resolve(channel);
+        })
+        .catch((error) => {
+          reject(error);
+        });
     });
   }
 }

--- a/src/classes/extensions/ExtendedClient.js
+++ b/src/classes/extensions/ExtendedClient.js
@@ -24,7 +24,7 @@ class ExtendedClient extends CommandoClient {
     }).then(() => {
       logger.info(`Presence updated to: ${presenceMessage}`);
     }).catch((error) => {
-      logger.error(error);
+      this.handleError(error);
     });
   }
 

--- a/src/commands/configuration/setMessage.js
+++ b/src/commands/configuration/setMessage.js
@@ -1,6 +1,6 @@
 import logger from '@greencoast/logger';
 import CustomCommand from '../../classes/extensions/CustomCommand';
-import { guildSettingKeys, discordErrors } from '../../common/constants';
+import { guildSettingKeys, discordErrors, SUPPORT_EMOJI } from '../../common/constants';
 import { isThisTheDiscordError } from '../../common/utils/helpers';
 
 class SetMessageCommand extends CustomCommand {
@@ -20,12 +20,17 @@ class SetMessageCommand extends CustomCommand {
   updateMessage(message, newMessage) {
     const previousValue = this.client.provider.get(message.guild, guildSettingKeys.ticketMessage);
 
-    if (previousValue === newMessage.id) {
+    if (previousValue?.message === newMessage.id) {
       message.reply('This message is already the ticket message.');
       return;
     }
 
-    this.client.provider.set(message.guild, guildSettingKeys.ticketMessage, newMessage.id);
+    const newTicket = { channel: newMessage.channel.id, message: newMessage.id };
+    this.client.provider.set(message.guild, guildSettingKeys.ticketMessage, newTicket);
+    newMessage.react(SUPPORT_EMOJI)
+      .catch((error) => {
+        this.onError(error, message);
+      });
     message.reply('The ticket message has been updated.');
     logger.info(`Changed ticket message for ${message.guild.name}.`);
   }

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -11,6 +11,10 @@ export const discordErrors = {
   unknownMessage: {
     name: 'DiscordAPIError',
     message: 'Unknown Message'
+  },
+  unknownChannelCategory: {
+    name: 'DiscordAPIError',
+    message: 'Invalid Form Body\nparent_id: Category does not exist'
   }
 };
 
@@ -27,3 +31,5 @@ export const activityType = {
   listening: 'LISTENING',
   watching: 'WATCHING'
 };
+
+export const SUPPORT_CHANNEL_PERMISSIONS = ['VIEW_CHANNEL', 'SEND_MESSAGES', 'READ_MESSAGE_HISTORY', 'EMBED_LINKS', 'ATTACH_FILES', 'USE_EXTERNAL_EMOJIS'];

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -15,6 +15,10 @@ export const discordErrors = {
   unknownChannelCategory: {
     name: 'DiscordAPIError',
     message: 'Invalid Form Body\nparent_id: Category does not exist'
+  },
+  missingPermissions: {
+    name: 'DiscordAPIError',
+    message: 'Missing Permissions'
   }
 };
 
@@ -33,3 +37,5 @@ export const activityType = {
 };
 
 export const SUPPORT_CHANNEL_PERMISSIONS = ['VIEW_CHANNEL', 'SEND_MESSAGES', 'READ_MESSAGE_HISTORY', 'EMBED_LINKS', 'ATTACH_FILES', 'USE_EXTERNAL_EMOJIS'];
+
+export const SUPPORT_EMOJI = '❗';

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -3,7 +3,8 @@ export const guildSettingKeys = {
   report: 'report',
   channelCategory: 'channel-category',
   staffRole: 'staff-role',
-  ticketMessage: 'ticket-message'
+  ticketMessage: 'ticket-message',
+  currentTickets: 'current-tickets'
 };
 
 export const discordErrors = {
@@ -11,4 +12,18 @@ export const discordErrors = {
     name: 'DiscordAPIError',
     message: 'Unknown Message'
   }
+};
+
+export const presenceStatus = {
+  online: 'online',
+  idle: 'idle',
+  invisible: 'invisible',
+  dnd: 'dnd'
+};
+
+export const activityType = {
+  playing: 'PLAYING',
+  streaming: 'STREAMING',
+  listening: 'LISTENING',
+  watching: 'WATCHING'
 };

--- a/test/classes/extensions/CustomCommand.spec.js
+++ b/test/classes/extensions/CustomCommand.spec.js
@@ -11,11 +11,7 @@ describe('Classes - Extensions - CustomCommand', () => {
   beforeEach(() => {
     messageMock.reply.mockClear();
     logger.info.mockClear();
-    logger.error.mockClear();
-    clientMock.provider.get.mockClear();
-    clientMock.owners.forEach((owner) => {
-      owner.send.mockClear();
-    });
+    clientMock.handleError.mockClear();
 
     command = new CustomCommand(clientMock, {
       name: 'command',
@@ -36,30 +32,15 @@ describe('Classes - Extensions - CustomCommand', () => {
       expect(messageMock.reply.mock.calls[0][0]).toBe('Something wrong happened when executing this command.');
     });
 
-    it('should log the error with error level logger.', () => {
+    it('should call client.handleError with the proper parameters.', () => {
       const error = new Error();
       command.onError(error, messageMock);
-      expect(logger.error.mock.calls.length).toBe(1);
-      expect(logger.error.mock.calls[0][0]).toBe(error);
-    });
 
-    it('should send a message to the owner if enabled.', () => {
-      const error = new Error();
-      clientMock.provider.get.mockImplementation(() => true);
-      command.onError(error, messageMock);
-      clientMock.owners.forEach((owner) => {
-        expect(owner.send.mock.calls.length).toBe(1);
-        expect(owner.send.mock.calls[0][0]).toBe(`An error occurred when running the command **${command.name}** in **${messageMock.guild.name}**. Triggering message: **${messageMock.content}** \`\`\`${error.stack}\`\`\``);
-      });
-    });
+      expect(clientMock.handleError.mock.calls.length).toBe(1);
+      expect(clientMock.handleError.mock.calls[0][0]).toBe(error);
+      expect(clientMock.handleError.mock.calls[0][1]).toBe(messageMock.guild);
+      expect(clientMock.handleError.mock.calls[0][2]).toBe(`An error occurred when running the command **${command.name}** in **${messageMock.guild.name}**. Triggering message: **${messageMock.content}**`);
 
-    it('should not send a message to the owner if disabled.', () => {
-      const error = new Error();
-      clientMock.provider.get.mockImplementation(() => false);
-      command.onError(error, messageMock);
-      clientMock.owners.forEach((owner) => {
-        expect(owner.send.mock.calls.length).toBe(0);
-      });
     });
   });
 

--- a/test/classes/extensions/CustomCommand.spec.js
+++ b/test/classes/extensions/CustomCommand.spec.js
@@ -40,7 +40,6 @@ describe('Classes - Extensions - CustomCommand', () => {
       expect(clientMock.handleError.mock.calls[0][0]).toBe(error);
       expect(clientMock.handleError.mock.calls[0][1]).toBe(messageMock.guild);
       expect(clientMock.handleError.mock.calls[0][2]).toBe(`An error occurred when running the command **${command.name}** in **${messageMock.guild.name}**. Triggering message: **${messageMock.content}**`);
-
     });
   });
 

--- a/test/classes/extensions/CustomCommand.spec.js
+++ b/test/classes/extensions/CustomCommand.spec.js
@@ -1,3 +1,4 @@
+import { Command } from 'discord.js-commando';
 import logger from '@greencoast/logger';
 import CustomCommand from '../../../src/classes/extensions/CustomCommand';
 import { clientMock, messageMock } from '../../../__mocks__/discordMocks';
@@ -22,6 +23,10 @@ describe('Classes - Extensions - CustomCommand', () => {
       memberName: 'group',
       description: 'desc'
     });
+  });
+
+  it('should be instance of Command.', () => {
+    expect(command).toBeInstanceOf(Command);
   });
 
   describe('onError()', () => {

--- a/test/classes/extensions/ExtendedClient.spec.js
+++ b/test/classes/extensions/ExtendedClient.spec.js
@@ -1,7 +1,9 @@
 import { CommandoClient } from 'discord.js-commando';
+import { Permissions } from 'discord.js';
 import logger from '@greencoast/logger';
 import ExtendedClient from '../../../src/classes/extensions/ExtendedClient';
-import { guildMock } from '../../../__mocks__/discordMocks';
+import { guildMock, userMock, channelMock } from '../../../__mocks__/discordMocks';
+import { guildSettingKeys, SUPPORT_CHANNEL_PERMISSIONS } from '../../../src/common/constants';
 
 jest.mock('@greencoast/logger');
 jest.mock('discord.js-commando', () => ({
@@ -11,7 +13,8 @@ jest.mock('discord.js-commando', () => ({
 // Have to mock the client here for the time being. Implementing a manual mock in __mocks__ may be a better idea.
 const client = new ExtendedClient();
 client.user = {
-  setPresence: jest.fn(() => Promise.resolve())
+  setPresence: jest.fn(() => Promise.resolve()),
+  id: '472'
 };
 client.guilds = {
   cache: {
@@ -20,7 +23,7 @@ client.guilds = {
   }
 };
 client.provider = {
-  get: jest.fn(() => ['one item'])
+  get: jest.fn()
 };
 
 describe('Classes - Extensions - ExtendedClient', () => {
@@ -34,6 +37,10 @@ describe('Classes - Extensions - ExtendedClient', () => {
   });
 
   describe('updatePresence()', () => {
+    beforeAll(() => {
+      client.provider.get.mockReturnValue(['one item']);
+    });
+
     it('should return a Promise.', () => {
       expect(client.updatePresence()).toBeInstanceOf(Promise);
     });
@@ -69,6 +76,114 @@ describe('Classes - Extensions - ExtendedClient', () => {
         .then(() => {
           expect(logger.error.mock.calls.length).toBe(1);
           expect(logger.error.mock.calls[0][0]).toBe(errorToReject);
+        });
+    });
+  });
+
+  describe('createSupportChannel()', () => {
+    const staffID = '132456789';
+    beforeAll(() => {
+      client.provider.get.mockReturnValue(staffID);
+      guildMock.channels.create.mockResolvedValue();
+      guildMock.roles.cache.map.mockReturnValue([]);
+    });
+
+    beforeEach(() => {
+      guildMock.channels.create.mockClear();
+      guildMock.roles.cache.map.mockClear();
+    });
+
+    it('should return a Promise.', () => {
+      expect(client.createSupportChannel(guildMock, userMock)).toBeInstanceOf(Promise);
+    });
+
+    it('should reject if no staff role is saved in database.', () => {
+      client.provider.get.mockImplementationOnce(() => null);
+      expect.assertions(1);
+
+      return client.createSupportChannel(guildMock, userMock)
+        .catch((error) => {
+          expect(error.message).toBe('Role does not exist in database.');
+        });
+    });
+
+    it('should reject if no channel category is saved in database.', () => {
+      client.provider.get.mockImplementation((_, key) => {
+        return key === guildSettingKeys.channelCategory ? null : true;
+      });
+      expect.assertions(1);
+
+      return client.createSupportChannel(guildMock, userMock)
+        .catch((error) => {
+          expect(error.message).toBe('Channel category does not exist in database.');
+        });
+    });
+
+    it('should resolve the newly created channel.', () => {
+      client.provider.get.mockReturnValue(staffID);
+      guildMock.channels.create.mockResolvedValueOnce(channelMock);
+
+      return client.createSupportChannel(guildMock, userMock)
+        .then((channel) => {
+          expect(channel).toBe(channelMock);
+        });
+    });
+
+    it('should resolve the channel with the correct name and parent.', () => {
+      client.provider.get.mockReturnValue(staffID);
+      guildMock.channels.create.mockImplementationOnce((name, options) => {
+        return Promise.resolve({
+          name,
+          parent: options.parent
+        });
+      });
+
+      return client.createSupportChannel(guildMock, userMock)
+        .then((channel) => {
+          expect(channel.name).toBe(`ticket-${userMock.username}`);
+          expect(channel.parent).toBe(staffID);
+        });
+    });
+
+    it('should call guild.channels.create with the proper permissions.', () => {
+      client.provider.get.mockReturnValue(staffID);
+      guildMock.channels.create.mockResolvedValueOnce();
+      guildMock.roles.cache.map.mockImplementation((cb) => {
+        return [{ id: '666' }, { id: staffID }].map(cb);
+      });
+
+      return client.createSupportChannel(guildMock, userMock)
+        .then(() => {
+          const expectedPermissions = [{
+            deny: Permissions.ALL,
+            id: '666',
+            type: 'role'
+          }, {
+            allow: new Permissions().add(...SUPPORT_CHANNEL_PERMISSIONS),
+            id: staffID,
+            type: 'role'
+          }, {
+            type: 'member',
+            id: userMock.id,
+            allow: new Permissions().add(...SUPPORT_CHANNEL_PERMISSIONS)
+          }, {
+            type: 'member',
+            id: client.user.id,
+            allow: new Permissions().add(...SUPPORT_CHANNEL_PERMISSIONS)
+          }];
+          expect(guildMock.channels.create.mock.calls[0][1].permissionOverwrites).toStrictEqual(expectedPermissions);
+        });
+    });
+
+    it('should reject if the channel creation rejected.', () => {
+      const rejectedError = new Error();
+      client.provider.get.mockReturnValue(staffID);
+      guildMock.channels.create.mockRejectedValueOnce(rejectedError);
+      expect.assertions(1);
+
+      return client.createSupportChannel(guildMock, userMock)
+        .catch((error) => {
+          expect(error).toBe(rejectedError);
         });
     });
   });

--- a/test/classes/extensions/ExtendedClient.spec.js
+++ b/test/classes/extensions/ExtendedClient.spec.js
@@ -124,8 +124,9 @@ describe('Classes - Extensions - ExtendedClient', () => {
       guildMock.channels.create.mockResolvedValueOnce(channelMock);
 
       return client.createSupportChannel(guildMock, userMock)
-        .then((channel) => {
+        .then(({ channel, staffRoleID }) => {
           expect(channel).toBe(channelMock);
+          expect(staffRoleID).toBe(staffID);
         });
     });
 
@@ -139,7 +140,7 @@ describe('Classes - Extensions - ExtendedClient', () => {
       });
 
       return client.createSupportChannel(guildMock, userMock)
-        .then((channel) => {
+        .then(({ channel }) => {
           expect(channel.name).toBe(`ticket-${userMock.username}`);
           expect(channel.parent).toBe(staffID);
         });

--- a/test/classes/extensions/ExtendedClient.spec.js
+++ b/test/classes/extensions/ExtendedClient.spec.js
@@ -1,0 +1,75 @@
+import { CommandoClient } from 'discord.js-commando';
+import logger from '@greencoast/logger';
+import ExtendedClient from '../../../src/classes/extensions/ExtendedClient';
+import { guildMock } from '../../../__mocks__/discordMocks';
+
+jest.mock('@greencoast/logger');
+jest.mock('discord.js-commando', () => ({
+  CommandoClient: jest.fn()
+}));
+
+// Have to mock the client here for the time being. Implementing a manual mock in __mocks__ may be a better idea.
+const client = new ExtendedClient();
+client.user = {
+  setPresence: jest.fn(() => Promise.resolve())
+};
+client.guilds = {
+  cache: {
+    array: jest.fn(() => [guildMock, guildMock, guildMock]),
+    reduce: jest.fn((cb, init) => client.guilds.cache.array().reduce(cb, init))
+  }
+};
+client.provider = {
+  get: jest.fn(() => ['one item'])
+};
+
+describe('Classes - Extensions - ExtendedClient', () => {
+  beforeEach(() => {
+    logger.info.mockClear();
+    logger.error.mockClear();
+  });
+
+  it('should be instance of CommandoClient.', () => {
+    expect(client).toBeInstanceOf(CommandoClient);
+  });
+
+  describe('updatePresence()', () => {
+    it('should return a Promise.', () => {
+      expect(client.updatePresence()).toBeInstanceOf(Promise);
+    });
+
+    it('should should set the correct presence if client has more other than 1 guild.', () => {
+      return client.updatePresence()
+        .then(() => {
+          const presenceMessage = '3 tickets open across 3 servers!';
+
+          expect(logger.info.mock.calls.length).toBe(1);
+          expect(logger.info.mock.calls[0][0]).toBe(`Presence updated to: ${presenceMessage}`);
+        });
+    });
+
+    it('should should set the correct presence if client has only 1 guild.', () => {
+      client.guilds.cache.array.mockReturnValueOnce([guildMock]);
+
+      return client.updatePresence()
+        .then(() => {
+          const presenceMessage = '3 tickets open!';
+
+          expect(logger.info.mock.calls.length).toBe(1);
+          expect(logger.info.mock.calls[0][0]).toBe(`Presence updated to: ${presenceMessage}`);
+        });
+    });
+
+    it('should log an error when rejected by setPresence().', () => {
+      const errorToReject = new Error();
+      client.user.setPresence.mockRejectedValueOnce(errorToReject);
+      expect.assertions(2);
+
+      return client.updatePresence()
+        .then(() => {
+          expect(logger.error.mock.calls.length).toBe(1);
+          expect(logger.error.mock.calls[0][0]).toBe(errorToReject);
+        });
+    });
+  });
+});

--- a/test/commands/configuration/setMessage.spec.js
+++ b/test/commands/configuration/setMessage.spec.js
@@ -90,6 +90,7 @@ describe('Commands - SetMessage', () => {
 
         messageMock.channel.messages.fetch.mockClear();
         logger.error.mockClear();
+        clientMock.handleError.mockClear();
         messageMock.channel.messages.fetch.mockRejectedValue(error);
         command = new SetMessageCommand(clientMock);
       });
@@ -105,6 +106,7 @@ describe('Commands - SetMessage', () => {
 
       it('should errorLog with error if the rejected error was not unknown channel discord error.', () => {
         error.name = 'Unknown Error';
+        clientMock.handleError.mockImplementationOnce((error) => logger.error(error));
         expect.assertions(2);
         return command.run(messageMock, [messageMock.id])
           .then(() => {

--- a/test/commands/configuration/setMessage.spec.js
+++ b/test/commands/configuration/setMessage.spec.js
@@ -49,7 +49,7 @@ describe('Commands - SetMessage', () => {
       });
 
       it('should reply with message already set if value was already saved.', () => {
-        clientMock.provider.get.mockImplementation(() => messageMock.id);
+        clientMock.provider.get.mockImplementation(() => ({ message: messageMock.id }));
         return command.run(messageMock, [messageMock.id])
           .then(() => {
             expect(messageMock.reply.mock.calls.length).toBe(1);
@@ -64,12 +64,14 @@ describe('Commands - SetMessage', () => {
             expect(clientMock.provider.set.mock.calls.length).toBe(1);
             expect(clientMock.provider.set.mock.calls[0][0]).toBe(messageMock.guild);
             expect(clientMock.provider.set.mock.calls[0][1]).toBe(guildSettingKeys.ticketMessage);
-            expect(clientMock.provider.set.mock.calls[0][2]).toBe(messageMock.id);
+            expect(clientMock.provider.set.mock.calls[0][2]).toStrictEqual({
+              channel: messageMock.channel.id, message: messageMock.id
+            });
           });
       });
 
       it('should reply with the message changed message if a new value was provided.', () => {
-        clientMock.provider.get.mockImplementation(() => 'old id');
+        clientMock.provider.get.mockImplementation(() => ({ channel: 'old id', message: 'old id' }));
         return command.run(messageMock, [messageMock.id])
           .then(() => {
             expect(messageMock.reply.mock.calls.length).toBe(1);

--- a/test/commands/configuration/setMessage.spec.js
+++ b/test/commands/configuration/setMessage.spec.js
@@ -57,7 +57,7 @@ describe('Commands - SetMessage', () => {
           });
       });
 
-      it('should save the message id to the db if a new value was provided.', () => {
+      it('should save the channel and message id to the db if a new value was provided.', () => {
         clientMock.provider.get.mockImplementation(() => 'old id');
         return command.run(messageMock, [messageMock.id])
           .then(() => {


### PR DESCRIPTION
### :pencil: Checklist

Make sure that your PR fulfills these requirements:

- [x] Tests have been added for this feature.
- [ ] Documentation has been added to this repo's wiki. (DOES NOT APPLY)
- [x] All tests pass on your local machine.
- [x] Code has been linted with the proper rules.
- [x] I have added the correct assignees for code review.

### :page_facing_up: Description

This PR moves the error reporting logic from CustomCommand to ExtendedClient to be used in out-of-command contexts.

### :pushpin: Does this PR address any issue?

No.
